### PR TITLE
retrieve full cover path when reading by file name

### DIFF
--- a/src/epub-thumbnailer.py
+++ b/src/epub-thumbnailer.py
@@ -77,6 +77,8 @@ def extract_cover(cover_path):
         cover = epub.open(cover_path)
         im = Image.open(StringIO(cover.read()))
         im.thumbnail((size, size), Image.ANTIALIAS)
+        if im.mode == "CMYK":
+            im = im.convert("RGB")
         im.save(output_file, "PNG")
         return True
     return False


### PR DESCRIPTION
1. In the strategy for retrieving the cover file by matching its name to a regex, previously the base name was being returned from the strategy function; which led to the script failing for epubs with covers within complex folder structures. Fixed so that full path of the cover is returned. Tested on Ubuntu Trusty with GNOME desktop.
2. While extracting covers if the original image is in CMYK mode then an error "cannot write mode CMYK as PNG" is thrown; fixed by checking mode and converting to RGB.
