### PR TITLE
Add detection and installation for tumbler

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,5 @@ This will look into the **epub_file** to find its cover, and will save a **size*
 - [Marcelo Lira](https://github.com/setanta): Improved cover detection by filename
 - [Pablo Jorge](https://github.com/pablojorge): Added manifest-based cover detection
 - [Renato Ramonda](https://github.com/renatoram): Added gnome3 thumbnailer support
+- [xtrymind](https://github.com/xtrymind): Added tumbler configuration
 - A [couple](http://ubuntuforums.org/showthread.php?t=278162) of [forum](http://ubuntuforums.org/showthread.php?t=1046678) [topics](http://library.gnome.org/devel/integration-guide/stable/thumbnailer.html.en) where I learned about the matter


### PR DESCRIPTION
This removes the need to manually add the thumbnailer
to tumbler.rc for end users.

Signed-off-by: Dede Dindin Qudsy <xtrymind@gmail.com>