### PR TITLE
fix check 'Ebook thumbnailer' on python3

### DIFF
--- a/install.py
+++ b/install.py
@@ -98,7 +98,7 @@ def check_tumbler():
 def add_thumbnailer_to_tumbler():
     with(open('/etc/xdg/tumbler/tumbler.rc', 'a+')) as tumbler_config:
         config_content = mmap.mmap(tumbler_config.fileno(), 0, access=mmap.ACCESS_READ)
-        if config_content.find('# Ebook thumbnailer') == -1:
+        if config_content.find(b'# Ebook thumbnailer') == -1:
             tumbler_config.write('\n')
             tumbler_config.write('# Ebook thumbnailer\n')
             tumbler_config.write('[EbookThumbnailer]\n')


### PR DESCRIPTION
i don't know it is just me or anyone else have same problem, but since migrate to python3, i got typeError:
```
Traceback (most recent call last):
  File "install.py", line 182, in <module>
    commands[args.action]()
  File "install.py", line 156, in install
    add_thumbnailer_to_tumbler()
  File "install.py", line 101, in add_thumbnailer_to_tumbler
    if config_content.find('# Ebook thumbnailer') == -1:
TypeError: a bytes-like object is required, not 'str 
```
i'm using Arch Linux and python 3.7.3