### PR TITLE
Add support for cinnamon

### DIFF
--- a/install.py
+++ b/install.py
@@ -72,6 +72,7 @@ VERSION_GUSSERS = {
     'openbox': lambda: 'openbox',
     'enlightenment': lambda: 'enlightenment',
     'i3': lambda: 'i3',
+    'cinnamon': lambda: 'gnome3'
 }
 KNOWN_DE = '|'.join(VERSION_GUSSERS.keys())
 


### PR DESCRIPTION
Add cinnamon to a list of recognizable environments and set its value to 'gnome3'.