### PR TITLE
Add pyproject.toml (fixes #42)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+script-files = ["src/epub-thumbnailer.py"]
+
+[project]
+name = "epub-thumbnailer"
+version = "0.0.1"
+authors = [
+  { name="Mariano Simone" },
+]
+description = "Script to extract the cover of an epub book and create a thumbnail for it"
+readme = "README.md"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "pillow"
+]
+
+[project.urls]
+Homepage = "https://github.com/marianosimone/epub-thumbnailer"
+Issues = "https://github.com/marianosimone/epub-thumbnailer/issues"


### PR DESCRIPTION
Add a basic pyproject.toml to allow installation using pipx command line as follows

`pipx install git+https://github.com/marianosimone/epub-thumbnailer` 


Possible fix for #42 